### PR TITLE
Fix progress bar initialization

### DIFF
--- a/tv_grab_fr_telerama
+++ b/tv_grab_fr_telerama
@@ -726,7 +726,7 @@ foreach my $chid (sort { $channels{$a}{order} <=> $channels{$b}{order} } keys %c
 
 # count needed api calls
 my $nb_chans = scalar(keys %channels);
-my $to_get = (int($nb_chans / $group_size) + ($nb_chans % $group_size > 0 ? 1 : 0)) * ($opt_days - $opt_offset);
+my $to_get = (int($nb_chans / $group_size) + ($nb_chans % $group_size > 0 ? 1 : 0)) * $opt_days;
 my $bar = new XMLTV::ProgressBar('getting listings', $to_get) if not $opt_quiet and not $show_url;
 
 Date_Init('SetDate=now,UTC');


### PR DESCRIPTION
In the actual version the _progress bar_ is initialized with `$nb_chans * ($opt_days - $opt_offset)`.
This has a null or negative value when` $opt_days` <= `$opt_offset`, which explains progress bar behavior in #55.

In fact as `--days` (and so `$op_days`) gives the number of days to grab, the _progress bar_ initialization should be:  _the number of channels to grab multiplied by the number of days to grab_.

This is what this PR does.